### PR TITLE
fix: update the link of zhihu

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A collection of awesome things related to Rax
 
 ### Rax Community
 
-- [知乎](zhuanlan.zhihu.com/raxjs)
+- [知乎](https://zhuanlan.zhihu.com/raxjs)
 - [React China](http://react-china.org/c/rax)
 
 ### Rax Tutorials


### PR DESCRIPTION
This PR update the link of zhihu to avoid the error: 

![image](https://user-images.githubusercontent.com/26642280/88450837-9213d680-ce84-11ea-818b-e588101570c3.png)


Signed-off-by: LinHaiming <lhming23@outlook.com>